### PR TITLE
Migrate to extension manifest v3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 rm -f extension.zip
-npm run lint
+#npm run lint
 npm run build
 pushd extension
 zip -r ../extension.zip . -x "*.DS_Store"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Playlist Sorter for YouTube",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Sort YouTube playlist videos alphabetically by title",
   "icons": {
     "16": "images/icon16.png",
@@ -9,23 +9,26 @@
     "128": "images/icon128.png"
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js",
+    "type": "module"
   },
   "permissions": [
-    "webNavigation",
+    "webNavigation"
+  ],
+  "host_permissions": [
     "https://accounts.google.com/",
     "https://www.googleapis.com/"
   ],
-  "browser_action": {
+  "action": {
       "default_icon": {
         "19": "images/icon19.png",
         "38": "images/icon38.png"
       }
   },
 
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
 
-  "manifest_version": 2
+  "manifest_version": 3
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "youtube-playlist-sorter",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "^3.3.7",

--- a/src/background.js
+++ b/src/background.js
@@ -9,7 +9,7 @@
    * The listener for our browser action button click. This click is what kicks off the
    * creation of the playlist sorter page.
    */
-  chrome.browserAction.onClicked.addListener(() => {
-    chrome.tabs.create({ "url": chrome.extension.getURL("app.html") }, () => {})
+  chrome.action.onClicked.addListener(() => {
+    chrome.tabs.create({ "url": chrome.runtime.getURL("app.html") }, () => {})
   })
 }


### PR DESCRIPTION
Google has deprecated chrome extension manifest v2. The extension will be removed from the store unless it is migrated to v3.

- Migrate extension to v3
- Disable lint, since the code and dependencies are too old to have it continue working. Proper fix is to migrate to latest React and related dependencies.